### PR TITLE
make sure css-loader uses modules

### DIFF
--- a/tutorials/pdf-split/webpack.config.js
+++ b/tutorials/pdf-split/webpack.config.js
@@ -17,7 +17,16 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        use: ['style-loader', 'css-loader'],
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              importLoaders: 1,
+              modules: true,
+            },
+          },
+        ],
       },
       {
         test: /\.(png|woff|woff2|eot|ttf|svg)$/,


### PR DESCRIPTION
CSS modules would work locally while testing, because Storybook has its own Webpack config where CSS modules were set up properly. This was not setup in the build script. You need to explicitly opt in to load `*.module.css` files as CSS modules with a config in `css-loader`.