### PR TITLE
update pdf-split component to support category selection

### DIFF
--- a/tutorials/pdf-split/.storybook/main.js
+++ b/tutorials/pdf-split/.storybook/main.js
@@ -10,7 +10,7 @@ module.exports = {
   webpackFinal: (config) => {
     const css_regex = '/\\.css$/';
     const cssRule = config.module.rules.find((_) => _.test.toString() === css_regex);
-    config.plugins.push(new webpack.DefinePlugin({ ___TUTORIAL_VERSION___: JSON.stringify(version) }));
+    config.plugins.push(new webpack.DefinePlugin({ ___PDF_SPLIT_VERSION___: JSON.stringify(version) }));
 
     return {
       ...config,

--- a/tutorials/pdf-split/package-lock.json
+++ b/tutorials/pdf-split/package-lock.json
@@ -1350,6 +1350,15 @@
         }
       }
     },
+    "@hypnosphi/create-react-context": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
+      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
+      "requires": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
@@ -1520,16 +1529,60 @@
       }
     },
     "@lucidtech/flyt-form": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@lucidtech/flyt-form/-/flyt-form-1.2.3.tgz",
-      "integrity": "sha512-Jh2NK2hnb5KU2jRQ6XKHOuFDgbHt6T/q8AKK/AGI3GSMU20C4X1YbvACf54YUqg6W/4ncY72ZEGeOEgPasQY+w==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lucidtech/flyt-form/-/flyt-form-1.3.4.tgz",
+      "integrity": "sha512-rZHR03Wi6jL8LynkmEBFJYQEsCuSMThRolfAy2/e8sQ3SQd7XIuMDK9ZZTvoTze2diD6A1Ubr9BsP0a6VLEuyA==",
       "requires": {
+        "@types/utif": "^3.0.1",
         "downshift": "^6.0.6",
         "react": "^16.13.1",
         "react-datepicker": "2.9.6",
         "react-dom": "^16.13.1",
+        "react-pdf": "^5.2.0",
         "react-switch": "^5.0.1",
-        "typescript": "^4.0.3"
+        "typescript": "^4.0.3",
+        "utif": "^3.1.0"
+      },
+      "dependencies": {
+        "pdfjs-dist": {
+          "version": "2.5.207",
+          "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.5.207.tgz",
+          "integrity": "sha512-xGDUhnCYPfHy+unMXCLCJtlpZaaZ17Ew3WIL0tnSgKFUZXHAPD49GO9xScyszSsQMoutNDgRb+rfBXIaX/lJbw=="
+        },
+        "react-pdf": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-5.2.0.tgz",
+          "integrity": "sha512-/vl+fzurHzz1o1knGSnLzFu1lL/1yb67JSE3WSX3bC/ioL/j34q5WiJbxK2D61Og0RZe6CNy9rve6JyB+sfHCw==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "make-cancellable-promise": "^1.0.0",
+            "make-event-props": "^1.1.0",
+            "merge-class-names": "^1.1.1",
+            "merge-refs": "^1.0.0",
+            "pdfjs-dist": "2.5.207",
+            "prop-types": "^15.6.2",
+            "worker-loader": "^3.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        },
+        "worker-loader": {
+          "version": "3.0.8",
+          "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-3.0.8.tgz",
+          "integrity": "sha512-XQyQkIFeRVC7f7uRhFdNMe/iJOdO6zxAaR3EWbDp45v3mDhrTi+++oswKNxShUNjPC/1xUp5DB29YKLhFo129g==",
+          "requires": {
+            "loader-utils": "^2.0.0",
+            "schema-utils": "^3.0.0"
+          }
+        }
       }
     },
     "@lucidtech/las-sdk-core": {
@@ -2741,8 +2794,7 @@
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
-      "dev": true
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
     },
     "@types/markdown-to-jsx": {
       "version": "6.11.3",
@@ -2780,8 +2832,7 @@
     "@types/node": {
       "version": "14.14.25",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
-      "dev": true
+      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
     },
     "@types/node-fetch": {
       "version": "2.5.8",
@@ -2916,6 +2967,14 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
+    },
+    "@types/utif": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/utif/-/utif-3.0.1.tgz",
+      "integrity": "sha512-PQ4MyFKw5ngbZDvrntyyojqbIqYsvrWt8wZEfJOlRjb3ZFPP98AUui4XbovmfoDELRDfsZX0MuohLYLkOMM1xg==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/webpack": {
       "version": "4.41.26",
@@ -5494,6 +5553,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
       "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
+      "dev": true,
       "requires": {
         "gud": "^1.0.0",
         "warning": "^4.0.3"
@@ -5674,9 +5734,9 @@
       "dev": true
     },
     "date-fns": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.17.0.tgz",
-      "integrity": "sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA=="
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.19.0.tgz",
+      "integrity": "sha512-X3bf2iTPgCAQp9wvjOQytnf5vO5rESYRXlPIVcgSbtT5OTScPcsf9eZU+B/YIkKAtYr5WeCii58BgATrNitlWg=="
     },
     "debug": {
       "version": "4.3.1",
@@ -9252,7 +9312,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
       "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -9344,7 +9403,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
       "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-      "dev": true,
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -9584,6 +9642,11 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
+    },
+    "merge-refs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.0.0.tgz",
+      "integrity": "sha512-WZ4S5wqD9FCR9hxkLgvcHJCBxzXzy3VVE6p8W2OzxRzB+hLRlcadGE2bW9xp2KSzk10rvp4y+pwwKO6JQVguMg=="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -10075,11 +10138,11 @@
       "dev": true
     },
     "object-is": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
-      "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
@@ -10350,8 +10413,7 @@
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parallel-transform": {
       "version": "1.2.0",
@@ -11735,12 +11797,12 @@
       }
     },
     "react-popper": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
-      "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
+      "integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
       "requires": {
         "@babel/runtime": "^7.1.2",
-        "create-react-context": "^0.3.0",
+        "@hypnosphi/create-react-context": "^0.3.1",
         "deep-equal": "^1.1.1",
         "popper.js": "^1.14.4",
         "prop-types": "^15.6.1",
@@ -14018,6 +14080,14 @@
       "dev": true,
       "requires": {
         "use-isomorphic-layout-effect": "^1.0.0"
+      }
+    },
+    "utif": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/utif/-/utif-3.1.0.tgz",
+      "integrity": "sha512-WEo4D/xOvFW53K5f5QTaTbbiORcm2/pCL9P6qmJnup+17eYfKaEhDeX9PeQkuyEoIxlbGklDuGl8xwuXYMrrXQ==",
+      "requires": {
+        "pako": "^1.0.5"
       }
     },
     "util": {

--- a/tutorials/pdf-split/package-lock.json
+++ b/tutorials/pdf-split/package-lock.json
@@ -1529,9 +1529,9 @@
       }
     },
     "@lucidtech/flyt-form": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@lucidtech/flyt-form/-/flyt-form-1.3.4.tgz",
-      "integrity": "sha512-rZHR03Wi6jL8LynkmEBFJYQEsCuSMThRolfAy2/e8sQ3SQd7XIuMDK9ZZTvoTze2diD6A1Ubr9BsP0a6VLEuyA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@lucidtech/flyt-form/-/flyt-form-1.4.0.tgz",
+      "integrity": "sha512-Lct0a5H950/HUjzo1gZC1atYtmEMwkrS7hDYekXR71aSkqUSXxDhIgLDkSa+3O1xm4oLWtwZcpD8ppxRA7pboQ==",
       "requires": {
         "@types/utif": "^3.0.1",
         "downshift": "^6.0.6",

--- a/tutorials/pdf-split/package.json
+++ b/tutorials/pdf-split/package.json
@@ -39,7 +39,7 @@
     "webpack-cli": "^4.2.0"
   },
   "dependencies": {
-    "@lucidtech/flyt-form": "^1.2.3",
+    "@lucidtech/flyt-form": "^1.3.4",
     "react-hotkeys": "^2.0.0",
     "react-pdf": "^5.0.0-beta.2"
   }

--- a/tutorials/pdf-split/package.json
+++ b/tutorials/pdf-split/package.json
@@ -39,7 +39,7 @@
     "webpack-cli": "^4.2.0"
   },
   "dependencies": {
-    "@lucidtech/flyt-form": "^1.3.4",
+    "@lucidtech/flyt-form": "^1.4.0",
     "react-hotkeys": "^2.0.0",
     "react-pdf": "^5.0.0-beta.2"
   }

--- a/tutorials/pdf-split/src/__fixtures__/Provider.tsx
+++ b/tutorials/pdf-split/src/__fixtures__/Provider.tsx
@@ -1,8 +1,9 @@
 import React, { ComponentType, useState } from 'react';
 import { Client as SDKClient } from '@lucidtech/las-sdk-core';
-import { Asset, TransitionExecution } from '@lucidtech/las-sdk-core/lib/types';
+import { Asset, TransitionExecution } from '@lucidtech/las-sdk-core';
 
 import documents from './documents';
+import assets from './assets';
 import { QueueStatus, RemoteComponentExternalProps } from '../types';
 import { createTransition, createTransitionExecution } from './props';
 
@@ -58,11 +59,12 @@ const PropProvider = ({ Component }: PropProviderProps): JSX.Element => {
     });
   };
 
-  const getAsset = async (_assetId: string): Promise<Asset> => {
-    return new Promise((_resolve, reject) => {
+  const getAsset = async (assetId: string): Promise<Asset> => {
+    return new Promise((resolve, _reject) => {
       setTimeout(() => {
-        return reject();
-      }, 1500);
+        const asset = assets[assetId];
+        return resolve(asset);
+      }, 1000);
     });
   };
 

--- a/tutorials/pdf-split/src/__fixtures__/assets.ts
+++ b/tutorials/pdf-split/src/__fixtures__/assets.ts
@@ -1,0 +1,35 @@
+import { Asset } from '@lucidtech/las-sdk-core';
+
+const fields = {
+  categories: {
+    type: 'string',
+    enum: [
+      { value: 'INVOICE', display: 'Faktura' },
+      { value: 'RECEIPT', display: 'Kvittering' },
+      { value: 'MULTIPLE_RECEIPTS', display: 'Flere kvitt.' },
+    ],
+    display: 'Dokument type',
+  },
+};
+
+function b64EncodeUnicode(str) {
+  // first we use encodeURIComponent to get percent-encoded UTF-8,
+  // then we convert the percent encodings into raw bytes which
+  // can be fed into btoa.
+  return btoa(
+    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, function toSolidBytes(_match, p1) {
+      return String.fromCharCode(Number('0x' + p1));
+    }),
+  );
+}
+
+const fieldsB64 = b64EncodeUnicode(JSON.stringify(fields));
+
+const assets: Record<string, Asset> = {
+  'las:asset:fieldConfig': {
+    assetId: 'las:asset:fieldConfig',
+    content: fieldsB64,
+  },
+};
+
+export default assets;

--- a/tutorials/pdf-split/src/__fixtures__/props.ts
+++ b/tutorials/pdf-split/src/__fixtures__/props.ts
@@ -24,7 +24,11 @@ export function createTransitionExecution(transitionId?: string): TransitionExec
     modelId: 'las:model:abc',
     predictionId: 'las:prediction:abc',
     timestamp: 0,
-    predictions: [],
+    predictions: [
+      { pages: [1], category: 'INVOICE' },
+      { pages: [2], category: 'RECEIPT' },
+      { pages: [3, 4], category: 'MULTIPLE_RECEIPTS' },
+    ],
   };
 
   const execution: TransitionExecution = {

--- a/tutorials/pdf-split/src/components/PDFViewer.module.css
+++ b/tutorials/pdf-split/src/components/PDFViewer.module.css
@@ -53,7 +53,7 @@
 
 .page-container {
   position: relative;
-  padding-left: 15px;
+  padding: 15px 15px 15px 30px;
   background-color: rgb(229, 241, 234);
   border-radius: 8px;
   margin-bottom: 15px;
@@ -85,7 +85,7 @@
 }
 
 .select {
-  margin: 5px;
+
 }
 
 .group-list {
@@ -94,7 +94,7 @@
   flex-wrap: wrap;
   list-style: none;
   margin: 0;
-  padding: 5px 15px 15px 15px;
+  padding: 0;
   border-radius: 10px;
 }
 

--- a/tutorials/pdf-split/src/components/PDFViewer.module.css
+++ b/tutorials/pdf-split/src/components/PDFViewer.module.css
@@ -85,7 +85,7 @@
 }
 
 .select {
-
+  max-width: 200px;
 }
 
 .group-list {

--- a/tutorials/pdf-split/src/components/PDFViewer.module.css
+++ b/tutorials/pdf-split/src/components/PDFViewer.module.css
@@ -84,7 +84,11 @@
   right: -39px;
 }
 
-.page-container ul {
+.select {
+  margin: 5px;
+}
+
+.group-list {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;

--- a/tutorials/pdf-split/src/components/PDFViewer.tsx
+++ b/tutorials/pdf-split/src/components/PDFViewer.tsx
@@ -109,6 +109,14 @@ const PDFViewer = ({
     setGroups(groupsCopy);
   };
 
+  const changeCategory = (groupIndex: number, category: EnumOption): void => {
+    const groupsCopy = [...groups];
+    const selectedGroup = groupsCopy[groupIndex];
+    selectedGroup.category = category;
+
+    setGroups(groupsCopy);
+  };
+
   // Split a group into two groups, where cutIndex indicates where the second group
   // should start.
   const cutGroup = (groupIndex: number, cutIndex: number): void => {
@@ -252,6 +260,9 @@ const PDFViewer = ({
                       className={styles.select}
                       selectedItem={group.category}
                       innerTabIndex={-1}
+                      handleSelectedItemChange={(item) =>
+                        item.selectedItem && changeCategory(groupIndex, item.selectedItem)
+                      }
                     />
                     <ul className={styles['group-list']}>
                       {group.pages.map((pageNumber, pageIndex) => {

--- a/tutorials/pdf-split/src/components/PDFViewer.tsx
+++ b/tutorials/pdf-split/src/components/PDFViewer.tsx
@@ -122,7 +122,7 @@ const PDFViewer = ({
       const hasPrevGroup = currentGroupIndex > 0;
 
       if (hasPrevGroup) {
-        const firstPageOfPrevGroup = groups[currentGroupIndex - 1][0];
+        const firstPageOfPrevGroup = groups[currentGroupIndex - 1].pages[0];
         onFocus(currentGroupIndex - 1, 0, firstPageOfPrevGroup);
         focusPage(firstPageOfPrevGroup);
       }
@@ -133,7 +133,7 @@ const PDFViewer = ({
       const hasNextGroup = currentGroupIndex >= 0 && currentGroupIndex !== groups.length - 1;
 
       if (hasNextGroup) {
-        const firstPageOfNextGroup = groups[currentGroupIndex + 1][0];
+        const firstPageOfNextGroup = groups[currentGroupIndex + 1].pages[0];
         onFocus(currentGroupIndex - 1, 0, firstPageOfNextGroup);
         focusPage(firstPageOfNextGroup);
       }

--- a/tutorials/pdf-split/src/components/PDFViewer.tsx
+++ b/tutorials/pdf-split/src/components/PDFViewer.tsx
@@ -146,6 +146,16 @@ const PDFViewer = ({
   };
 
   const handlers = {
+    // focus the select in the current group
+    FOCUS_CATEGORY: () => {
+      const currentGroupIndex = groups.findIndex((group) => group.pages.includes(previewPage));
+      if (currentGroupIndex >= 0) {
+        const selectElements: NodeListOf<HTMLButtonElement> | undefined = groupContainerRef.current?.querySelectorAll(
+          `.${styles.select} button`,
+        );
+        selectElements?.[currentGroupIndex]?.focus();
+      }
+    },
     // focus first page in previous group
     SELECT_PREV_GROUP: () => {
       const currentGroupIndex = groups.findIndex((group) => group.pages.includes(previewPage));
@@ -203,6 +213,10 @@ const PDFViewer = ({
 
   // react-hotkeys types aren't 100% correct sadly
   const keyMap: any = {
+    FOCUS_CATEGORY: {
+      name: 'Select group category',
+      sequences: ['shift+a'],
+    },
     SELECT_PREV_GROUP: {
       name: 'Move to previous group',
       sequences: ['ctrl+left'],

--- a/tutorials/pdf-split/src/components/PDFViewer.tsx
+++ b/tutorials/pdf-split/src/components/PDFViewer.tsx
@@ -9,7 +9,6 @@ import Spinner from './Spinner';
 import { GroupPrediction, Groups } from '..';
 import { Select } from '@lucidtech/flyt-form';
 import { EnumOption } from '../types';
-import { normalizeEnum } from '../utils';
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
 const options = {
@@ -77,7 +76,10 @@ const PDFViewer = ({
     } else if (predictions && predictions.length > 0) {
       const mapped: Groups = predictions.map((prediction) => ({
         ...prediction,
-        category: categoryLookup.get(prediction.category) || prediction.category,
+        category: {
+          display: categoryLookup.get(prediction.category) || prediction.category,
+          value: prediction.category,
+        },
       }));
       setGroups(mapped);
     }
@@ -249,7 +251,7 @@ const PDFViewer = ({
                       options={categories}
                       className={styles.select}
                       selectedItem={group.category}
-                      tabIndex={-1}
+                      innerTabIndex={-1}
                     />
                     <ul className={styles['group-list']}>
                       {group.pages.map((pageNumber, pageIndex) => {

--- a/tutorials/pdf-split/src/components/PDFViewer.tsx
+++ b/tutorials/pdf-split/src/components/PDFViewer.tsx
@@ -245,7 +245,12 @@ const PDFViewer = ({
                 return (
                   <div key={groupKey} className={styles['page-container']}>
                     <div className={styles['group-tab']}>{(groupIndex + 1).toString().padStart(2, '0')}</div>
-                    <Select options={categories} className={styles.select} selectedItem={group.category} />
+                    <Select
+                      options={categories}
+                      className={styles.select}
+                      selectedItem={group.category}
+                      tabIndex={-1}
+                    />
                     <ul className={styles['group-list']}>
                       {group.pages.map((pageNumber, pageIndex) => {
                         const hasPrevPage = pageIndex !== 0;

--- a/tutorials/pdf-split/src/components/PDFViewer.tsx
+++ b/tutorials/pdf-split/src/components/PDFViewer.tsx
@@ -7,6 +7,8 @@ import ScissorButton from './ScissorButton';
 import MergeButton from './MergeButton';
 import Spinner from './Spinner';
 import { Groups } from 'src';
+import { Select } from '@lucidtech/flyt-form';
+import { EnumOption } from 'src/types';
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;
 const options = {
@@ -22,6 +24,7 @@ type PDFViewerProps = {
   extraKeymap?: Record<string, any>;
   extraHandlers?: Record<string, any>;
   predictions?: Groups;
+  categories?: Array<EnumOption>;
 };
 
 const PDFViewer = ({
@@ -32,6 +35,7 @@ const PDFViewer = ({
   extraHandlers = {},
   extraKeymap = {},
   predictions,
+  categories = [],
 }: PDFViewerProps): JSX.Element => {
   const [numPages, setNumPages] = useState<number | null>(null);
   const [previewPage, setPreviewPage] = useState(1);
@@ -56,7 +60,7 @@ const PDFViewer = ({
     // if no predictions, group all pages together by default
     if (!predictions || predictions?.length === 0) {
       const allPages = [...Array(numPages).keys()].map((key) => key + 1);
-      setGroups([{ pages: allPages, category: 'INVOICE' }]);
+      setGroups([{ pages: allPages, category: '' }]);
     } else if (predictions && predictions.length > 0) {
       setGroups(predictions);
       console.log(predictions);
@@ -225,7 +229,8 @@ const PDFViewer = ({
                 return (
                   <div key={groupKey} className={styles['page-container']}>
                     <div className={styles['group-tab']}>{(groupIndex + 1).toString().padStart(2, '0')}</div>
-                    <ul>
+                    <Select options={categories} className={styles.select} selectedItem={group.category} />
+                    <ul className={styles['group-list']}>
                       {group.pages.map((pageNumber, pageIndex) => {
                         const hasPrevPage = pageIndex !== 0;
                         const hasNextPage = pageIndex !== group.pages.length - 1;

--- a/tutorials/pdf-split/src/index.tsx
+++ b/tutorials/pdf-split/src/index.tsx
@@ -7,7 +7,7 @@ import PDFViewer from './components/PDFViewer';
 import HotkeyHint from './components/HotkeyHint';
 
 import styles from './index.module.css';
-import { b64DecodeUnicode, normalizeEnum } from './utils';
+import { b64DecodeUnicode, normalizeEnum, normalizeString } from './utils';
 
 declare const ___PDF_SPLIT_VERSION___: string;
 
@@ -38,7 +38,6 @@ const RemoteComponent = ({
   const [isLoadingAsset, setIsLoadingAsset] = useState(true);
   const [groups, setGroups] = useState<Groups>([]);
   const [categories, setCategories] = useState<Array<EnumOption>>([]);
-  console.log(groups);
 
   // keybinds
   const [showKeybinds, setShowKeybinds] = useState(true);
@@ -122,9 +121,13 @@ const RemoteComponent = ({
 
   const approve = () => {
     const input = transitionExecution?.input || {};
+    const normalizedOutput: Array<GroupPrediction> = groups.map((group) => {
+      return { ...group, category: normalizeString(group.category) };
+    });
+
     const payload = {
       ...input,
-      verified: groups,
+      verified: normalizedOutput,
     };
     onApprove(payload);
     onRequestNew();

--- a/tutorials/pdf-split/src/index.tsx
+++ b/tutorials/pdf-split/src/index.tsx
@@ -15,7 +15,7 @@ export type Group = {
   category: Category;
 };
 export type Groups = Array<Group>;
-export type Category = 'INVOICE' | 'RECEIPT' | 'MULTIPLE_RECEIPTS';
+export type Category = 'INVOICE' | 'RECEIPT' | 'MULTIPLE_RECEIPTS' | 'MISC';
 
 const RemoteComponent = ({
   transitionExecution,

--- a/tutorials/pdf-split/src/index.tsx
+++ b/tutorials/pdf-split/src/index.tsx
@@ -8,7 +8,14 @@ import HotkeyHint from './components/HotkeyHint';
 
 import styles from './index.module.css';
 
-declare const ___TUTORIAL_VERSION___: string;
+declare const ___PDF_SPLIT_VERSION___: string;
+
+export type Group = {
+  pages: Array<number>;
+  category: Category;
+};
+export type Groups = Array<Group>;
+export type Category = 'INVOICE' | 'RECEIPT' | 'MULTIPLE_RECEIPTS';
 
 const RemoteComponent = ({
   transitionExecution,
@@ -22,7 +29,7 @@ const RemoteComponent = ({
   const [doc, setDoc] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [isLoadingDocument, setIsLoadingDocument] = useState(true);
-  const [groups, setGroups] = useState<Array<Array<number>>>([]);
+  const [groups, setGroups] = useState<Groups>([]);
 
   // keybinds
   const [showKeybinds, setShowKeybinds] = useState(true);
@@ -193,7 +200,7 @@ const RemoteComponent = ({
             </div>
           </div>
         </form>
-        <p className="text-muted small text-right">Version: {___TUTORIAL_VERSION___}</p>
+        <p className="text-muted small text-right">Version: {___PDF_SPLIT_VERSION___}</p>
       </div>
     </div>
   );

--- a/tutorials/pdf-split/src/index.tsx
+++ b/tutorials/pdf-split/src/index.tsx
@@ -13,6 +13,10 @@ declare const ___PDF_SPLIT_VERSION___: string;
 
 export type Group = {
   pages: Array<number>;
+  category: EnumOption | string;
+};
+export type GroupPrediction = {
+  pages: Array<number>;
   category: string;
 };
 export type Groups = Array<Group>;
@@ -34,6 +38,7 @@ const RemoteComponent = ({
   const [isLoadingAsset, setIsLoadingAsset] = useState(true);
   const [groups, setGroups] = useState<Groups>([]);
   const [categories, setCategories] = useState<Array<EnumOption>>([]);
+  console.log(groups);
 
   // keybinds
   const [showKeybinds, setShowKeybinds] = useState(true);

--- a/tutorials/pdf-split/src/types.ts
+++ b/tutorials/pdf-split/src/types.ts
@@ -3,11 +3,7 @@ import { Asset, Transition, TransitionExecution } from '@lucidtech/las-sdk-core/
 
 export enum QueueStatus {
   LOADING = 'LOADING',
-  LOADING_FIRST_TASK = 'LOADING_FIRST_TASK',
-  EMPTY = 'EMPTY',
   READY = 'READY',
-  TIMEOUT = 'TIMEOUT',
-  REFRESH = 'REFRESH',
 }
 
 export type RemoteComponentExternalProps = {
@@ -22,4 +18,18 @@ export type RemoteComponentExternalProps = {
   queueStatus: QueueStatus;
   transitionExecution: TransitionExecution;
   client: Client;
+};
+
+export type EnumOption =
+  | {
+      display: string;
+      value: string;
+    }
+  | string;
+
+export type Field = {
+  type: string;
+  display: string;
+  enum?: Array<EnumOption>;
+  confidenceLevels: { automated: number; highest: number; high: number; low: number };
 };

--- a/tutorials/pdf-split/src/utils.ts
+++ b/tutorials/pdf-split/src/utils.ts
@@ -1,0 +1,20 @@
+import { EnumOption } from './types';
+
+export function normalizeEnum(str: string): EnumOption {
+  return { value: str, display: str };
+}
+
+/**
+ * Decode base64 encoded content to unicode string
+ * @param str
+ */
+export function b64DecodeUnicode(str: string): string {
+  return decodeURIComponent(
+    atob(str)
+      .split('')
+      .map(function (c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+      })
+      .join(''),
+  );
+}

--- a/tutorials/pdf-split/src/utils.ts
+++ b/tutorials/pdf-split/src/utils.ts
@@ -4,6 +4,14 @@ export function normalizeEnum(str: string): EnumOption {
   return { value: str, display: str };
 }
 
+export function normalizeString(enumOption: EnumOption): string {
+  if (typeof enumOption === 'object') {
+    return enumOption.value;
+  } else {
+    return enumOption;
+  }
+}
+
 /**
  * Decode base64 encoded content to unicode string
  * @param str

--- a/tutorials/pdf-split/webpack.config.js
+++ b/tutorials/pdf-split/webpack.config.js
@@ -46,5 +46,5 @@ module.exports = {
   externals: {
     react: 'react',
   },
-  plugins: [new webpack.DefinePlugin({ ___TUTORIAL_VERSION___: JSON.stringify(version) })],
+  plugins: [new webpack.DefinePlugin({ ___PDF_SPLIT_VERSION___: JSON.stringify(version) })],
 };


### PR DESCRIPTION
Adds a dropdown selection to each group of pages, allowing you to select the type of document each group belong to, using a `fieldConfig` asset with a `categories` field:

```json
{
  "categories": {
    "type": "string",
    "enum": [
      { "value": "INVOICE", "display": "Faktura" },
      { "value": "RECEIPT", "display": "Kvittering" },
      { "value": "MULTIPLE_RECEIPTS", "display": "Flere kvitt." },
    ],
    "display": "Dokument type",
  },
}
```