### PR TITLE
fix confidence thresholds in remote component

### DIFF
--- a/tutorials/simple-demo/frontend/src/__fixtures__/assets.ts
+++ b/tutorials/simple-demo/frontend/src/__fixtures__/assets.ts
@@ -5,32 +5,32 @@ const fields = {
     type: 'string',
     enum: [{ value: 'INVOICE', display: 'Faktura' }, { value: 'REMINDER', display: 'Purring' }, 'CREDITNOTE'],
     display: 'Dokument type',
-    confidenceLevels: { automated: 0.98, highest: 0.97, high: 0.9, low: 0.5 },
+    confidenceLevels: { automated: 0.98, high: 0.95, medium: 0.75, low: 0.5 },
   },
   bank_account: {
     type: 'string',
     display: 'Bank account',
-    confidenceLevels: { automated: 0.98, highest: 0.97, high: 0.9, low: 0.5 },
+    confidenceLevels: { automated: 0.98, high: 0.95, medium: 0.7, low: 0.5 },
   },
   due_date: {
     type: 'date',
     display: 'Due date',
-    confidenceLevels: { automated: 0.98, highest: 0.97, high: 0.9, low: 0.5 },
+    confidenceLevels: { automated: 0.98, high: 0.95, medium: 0.7, low: 0.5 },
   },
   invoice_date: {
     type: 'date',
     display: 'Invoice date',
-    confidenceLevels: { automated: 0.98, highest: 0.97, high: 0.9, low: 0.5 },
+    confidenceLevels: { automated: 0.98, high: 0.95, medium: 0.7, low: 0.5 },
   },
-  total: {
+  total_amount: {
     type: 'amount',
     display: 'Total amount',
-    confidenceLevels: { automated: 0.98, highest: 0.97, high: 0.9, low: 0.5 },
+    confidenceLevels: { automated: 0.98, high: 0.95, medium: 0.7, low: 0.5 },
   },
   buyer: {
     type: 'buyer',
     display: 'Kjøper',
-    confidenceLevels: { automated: 0.98, highest: 0.97, high: 0.9, low: 0.5 },
+    confidenceLevels: { automated: 0.98, high: 0.95, medium: 0.7, low: 0.5 },
   },
 };
 

--- a/tutorials/simple-demo/frontend/src/__fixtures__/props.ts
+++ b/tutorials/simple-demo/frontend/src/__fixtures__/props.ts
@@ -41,6 +41,21 @@ export function createTransitionExecution(transitionId?: string, documentId = ''
         value: '21.01.2021',
         confidence: 0.913426,
       },
+      {
+        label: 'invoice_date',
+        value: '04.01.2021',
+        confidence: 0.4903426,
+      },
+      {
+        label: 'total_amount',
+        value: '3213,10',
+        confidence: 0.69,
+      },
+      {
+        label: 'buyer',
+        value: '19382',
+        confidence: 0.95,
+      },
     ],
   };
 

--- a/tutorials/simple-demo/frontend/src/types.ts
+++ b/tutorials/simple-demo/frontend/src/types.ts
@@ -28,5 +28,5 @@ export type Field = {
   type: string;
   display: string;
   enum?: Array<EnumOption | string>;
-  confidenceLevels: { automated: number; highest: number; high: number; low: number };
+  confidenceLevels: { automated: number; high: number; medium: number; low: number };
 };


### PR DESCRIPTION
- Fixes a little label mismatch between the flyt-form library and fieldConfig keys
- Avoid showing predictions with a lower confidence that the low threshold (or a default of 0.5)