### PR TITLE
use folder specific versioning for remote components

### DIFF
--- a/tutorials/bounding-box-crop/webpack.config.js
+++ b/tutorials/bounding-box-crop/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const execSync = require('child_process').execSync;
 const webpack = require('webpack');
 
-const version = execSync('git rev-parse --short HEAD', { encoding: 'ascii' });
+const version = execSync(`git rev-list -1 --abbrev-commit HEAD -- ${__dirname}`, { encoding: 'ascii' });
 
 module.exports = {
   entry: path.resolve(__dirname, './src/index.tsx'),

--- a/tutorials/pdf-split/webpack.config.js
+++ b/tutorials/pdf-split/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const execSync = require('child_process').execSync;
 const webpack = require('webpack');
 
-const version = execSync('git rev-parse --short HEAD', { encoding: 'ascii' });
+const version = execSync(`git rev-list -1 --abbrev-commit HEAD -- ${__dirname}`, { encoding: 'ascii' });
 
 module.exports = {
   entry: path.resolve(__dirname, './src/index.tsx'),

--- a/tutorials/simple-demo/frontend/webpack.config.js
+++ b/tutorials/simple-demo/frontend/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const execSync = require('child_process').execSync;
 const webpack = require('webpack');
 
-const version = execSync('git rev-parse --short HEAD', { encoding: 'ascii' });
+const version = execSync(`git rev-list -1 --abbrev-commit HEAD -- ${__dirname}`, { encoding: 'ascii' });
 
 module.exports = {
   entry: path.resolve(__dirname, './src/index.tsx'),


### PR DESCRIPTION
This prevents a version difference when building, when only other files in the repo has had commits/changes.